### PR TITLE
add height to movie-tile to avoid holes in display

### DIFF
--- a/fresh_tomatoes.py
+++ b/fresh_tomatoes.py
@@ -36,8 +36,8 @@ main_page_head = '''
             height: 100%;
         }
         .movie-tile {
-            margin-bottom: 20px;
             padding-top: 20px;
+            height: 460px;
         }
         .movie-tile:hover {
             background-color: #EEE;

--- a/fresh_tomatoes.py
+++ b/fresh_tomatoes.py
@@ -36,8 +36,8 @@ main_page_head = '''
             height: 100%;
         }
         .movie-tile {
-            padding-top: 20px;
-            height: 460px;
+            margin-bottom: 20px;
+            height: 450px;
         }
         .movie-tile:hover {
             background-color: #EEE;


### PR DESCRIPTION
Valid for titles of up to 3 lines long. Then the titles cover go under the next poster, but at least it doesn't leave spaces: https://discussions.udacity.com/t/placement-problem-in-webpage/157873
