### PR TITLE
Fix unequal column display height issue

### DIFF
--- a/fresh_tomatoes.py
+++ b/fresh_tomatoes.py
@@ -35,13 +35,23 @@ main_page_head = '''
             width: 100%;
             height: 100%;
         }
+        .container {
+            display: flex;
+            flex-wrap: wrap;
+        }
         .movie-tile {
+            display: flex;
+            flex-direction: column;
             margin-bottom: 20px;
             padding-top: 20px;
         }
         .movie-tile:hover {
             background-color: #EEE;
             cursor: pointer;
+        }
+        .movie-poster {
+            margin-right: auto;
+            margin-left: auto;
         }
         .scale-media {
             padding-bottom: 56.25%;
@@ -123,7 +133,7 @@ main_page_content = '''
 # A single movie entry html template
 movie_tile_content = '''
 <div class="col-md-6 col-lg-4 movie-tile text-center" data-trailer-youtube-id="{trailer_youtube_id}" data-toggle="modal" data-target="#trailer">
-    <img src="{poster_image_url}" width="220" height="342">
+    <img class="movie-poster" src="{poster_image_url}" width="220" height="342">
     <h2>{movie_title}</h2>
 </div>
 '''


### PR DESCRIPTION
Previously, if a movie title overflowed into two lines, that movie-tile
div became longer than the others, causing the movie-tile divs in the
row below to be shifted to the right of the long div.  Changing the
display to flex fixes that problem.